### PR TITLE
createDefaultBindings selectors need apostrophes

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -393,7 +393,7 @@
             attributeName = $(foundEl).attr(attributeType);
 
             if(!bindings[attributeName]){
-                var attributeBinding =  {selector: '[' + attributeType + '=' + attributeName + ']'};
+                var attributeBinding =  {selector: '[' + attributeType + '="' + attributeName + '"]'};
                 bindings[attributeName] = attributeBinding;
 
                 if(converter){


### PR DESCRIPTION
Attribute selectors like these:

```
[name=my-name]
```

are invalid when containing certain characters like dots.
The attribute-selector requires the use of apostrophes:

```
[name="my-name"]
```

I came across this issue when working with DeepModel, using dot-notation in my attribute values:

```
[name="library.book.page"]
```
