### PR TITLE
Fixing array syntax error in "You can define multiple jQuery selectors" ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The jQuery string is a hash parameter named `selector`.
 You can define arrays of `selector` arguments in your bindings as shown in the example below.
 
 ````
- firstName: [{selector: '#firstName'}, {selector: '#title'}}
+ firstName: [{selector: '#firstName'}, {selector: '#title'}]
 ````
 
 In the example above, model.firstName is bound to an element with the id of "firstName" and an element with the id of "title".


### PR DESCRIPTION
...example.

I actually haven't tried the example yet so I'm just taking a stab at the correction.
