### PR TITLE
Fix for class setElAttribute with boolean model attributes

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -269,7 +269,7 @@
                     break;
                 case 'class':
                     var previousValue = this._model.previous(elementBinding.attributeBinding.attributeName);
-                    if(previousValue){
+                    if(!_.isUndefined(previousValue)){
                         previousValue = this._getConvertedValue(Backbone.ModelBinder.Constants.ModelToView, elementBinding, previousValue);
                         el.removeClass(previousValue);
                     }


### PR DESCRIPTION
If a model defines a boolean attribute and <code>this._model.previous(elementBinding.attributeBinding.attributeName)</code> returns false for the previous boolean attribute value, then the the existing if statement fails to remove the previous class.  I changed the condition to require a defined value.  

Backbone function definition for previous could also return null
<code>
    previous: function(attr) {
      if (!arguments.length || !this._previousAttributes) return null;
      return this._previousAttributes[attr];
    }
</code>

I did not add a check for null as model attribute values could also be null.
