### PR TITLE
stop model-to-view when processing view-to-model

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -211,10 +211,14 @@
             return undefined;
         },
 
-        _onModelChange:function () {
+        _onModelChange:function (model, options) {
+            if (options && options.changeSource === 'ModelBinder'){
+              return
+            }
+
             var changedAttribute, attributeBinding;
 
-            for (changedAttribute in this._model.changedAttributes()) {
+            for (changedAttribute in model.changedAttributes()) {
                 attributeBinding = this._attributeBindings[changedAttribute];
                 if (attributeBinding) {
                     this._copyModelToView(attributeBinding);


### PR DESCRIPTION
Please let me clarify the process I understand ModelBinder's doing -

0 Bind Model & View
1 Dom changes, and then copyViewToModel
2 Model changes, and then triggers its 'change' event
3 Model 'change' listener '_onModelChange'  executes copyModelToView
4 View changes, but we use jQuery method and won't trigger View's 'change' event.

I think we would and should shortcircuit step 3 if the model is changed by our view.

Thanks,
