### PR TITLE
Log non-critical errors to the console instead of stopping all script execution.

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -142,7 +142,7 @@
                         foundEls = $(elementBinding.selector, this._rootEl);
                     }
 
-                    if (foundEls.length === 0 && console) {
+                    if (foundEls.length === 0) {
                         warn( 'Bad binding found. No elements returned for binding selector ' + elementBinding.selector );
                     }
                     else {


### PR DESCRIPTION
I added a `warn` function to log errors that can be recovered from. For example, if there are bindings that return no elements, they can just be ignored. I also cleanup code to call `unbind` if no bindings were created.
