### PR TITLE
Added options parameter which is forwarded to backbone set

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -16,8 +16,9 @@
         throw 'Please include Backbone.js before Backbone.ModelBinder.js';
     }
 
-    Backbone.ModelBinder = function(){
+    Backbone.ModelBinder = function(options){
         _.bindAll(this);
+	this._options = options || {};
     };
 
     // Current version of the library.
@@ -28,11 +29,12 @@
 
     _.extend(Backbone.ModelBinder.prototype, {
 
-        bind:function (model, rootEl, attributeBindings) {
+        bind:function (model, rootEl, attributeBindings, options) {
             this.unbind();
 
             this._model = model;
             this._rootEl = rootEl;
+	    this._options = _.extend({}, this._options, options);
 
             if (!this._model) throw 'model must be specified';
             if (!this._rootEl) throw 'rootEl must be specified';
@@ -361,7 +363,8 @@
             var elVal = this._getElValue(elementBinding, el);
             elVal = this._getConvertedValue(Backbone.ModelBinder.Constants.ViewToModel, elementBinding, elVal);
             data[elementBinding.attributeBinding.attributeName] = elVal;
-            this._model.set(data, {changeSource: 'ModelBinder'});
+	    var opts = _.extend({}, this._options, {changeSource: 'ModelBinder'});
+            this._model.set(data, opts);
         },
 
         _getConvertedValue: function (direction, elementBinding, value) {


### PR DESCRIPTION
I've added an options parameter to both the constructor and the bind method on Backbone.ModelBinder that will be forwarded along to the set method on backbone models. This allows users to specify some settings to forward to backbone when the model binder performs its actions.

Some example usage either when creating an instance of ModelBinder or calling the bind method:

``` javascript
var myView = Backbone.view.extend({
  initialize: {
    this._modelBinder = new Backbone.ModelBinder({silent: true});
    this._attributeBindings = {};
  },
  render: function() {
    // Perform some rendering
    var options = { moreOptionsHere: true };
    this._modelBinder.bind(this.model, this.el, this._attributeBindings, options);
  }
});
```
