### PR TITLE
use element's "input" event (HTML5) as well as "change"

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -173,14 +173,14 @@
         },
 
         _bindViewToModel:function () {
-            $(this._rootEl).delegate('', 'change', this._onElChanged);
+            $(this._rootEl).delegate('', 'change input', this._onElChanged);
             // The change event doesn't work properly for contenteditable elements - but blur does
             $(this._rootEl).delegate('[contenteditable]', 'blur', this._onElChanged);
         },
 
         _unbindViewToModel: function(){
             if(this._rootEl){
-                $(this._rootEl).undelegate('', 'change', this._onElChanged);
+                $(this._rootEl).undelegate('', 'change input', this._onElChanged);
                 $(this._rootEl).undelegate('[contenteditable]', 'blur', this._onElChanged);
             }
         },


### PR DESCRIPTION
In modern browsers it seems better to use the new "input" event rather than "change", so that the event fires even if the form control has not lost focus.

If there's some reason not to do this by default, then it would be good to have it at least be an option for those who want it.
