### PR TITLE
Fixing the ViewManagerFactory's getEl function

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -270,7 +270,7 @@
                 },
 
                 getEl: function(){
-                    return this._view.el;
+                    return this._view.$el;
                 }
             };
 


### PR DESCRIPTION
The getEl function should return a jQuery object. The caller of the getEl method assumes that and throws an exception if getEl doesn't return a jQuery object.
