### PR TITLE
removing 'checked' attr from input[type="radio"] when setting value is d...

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -310,6 +310,9 @@
                         if (el.val() === convertedValue) {
                             el.attr('checked', 'checked');
                         }
+                        else {
+                            el.removeAttr('checked');
+                        }
                         break;
                     case 'checkbox':
                         if (convertedValue) {


### PR DESCRIPTION
...ifferent from el.val()

Now behaviour will be similar to input[type="checkbox"].
This will allow correct behaviour with radios when calling model.unset
or model.set with value not existing in radios - after this operations
none radio will be checked.
