### PR TITLE
Collected bindings initialization in one place, added 'id' and 'data-bind' attributes auto-binding

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -18,7 +18,9 @@
 
     Backbone.ModelBinder = function(modelSetOptions){
         _.bindAll(this);
-	this._modelSetOptions = modelSetOptions || {};
+        this._modelSetOptions = modelSetOptions || {
+            select: ['name', 'id', 'data-bind']  // Attributes to which we're binding
+        };
     };
 
     // Current version of the library.
@@ -48,7 +50,15 @@
             }
             else {
                 // Default bindings generated from static method
-                self._attributeBindings = Backbone.ModelBinder.createDefaultBindings(rootEl, 'name');
+                var self = this;
+                _.each(this._modelSetOptions.select, function (attr, index) {
+                    if (self._attributeBindings) {
+                        Backbone.ModelBinder.combineBindings(self._attributeBindings, Backbone.ModelBinder.createDefaultBindings(rootEl, attr));
+                    } else {
+
+                    }
+
+                });
 
                 this._initializeAttributeBindings();
                 this._initializeElBindings();


### PR DESCRIPTION
Github doesn't allow me to make pull requests for separate commits, so I will collect all I wanted to pull in ths request.

I changed a bit library's API:
- now `createDefaultBindings` used for initializing and as static method
- `createDefaultBindings` search bindings for 'id', 'name' and 'data-bind' attributes
- I added simple parsing rule `DOM attribute - model attribute` for DOM elemts, so `<div data-bind="hidden IsHidden">` works well
- Fixed cobine bindings utility, now it can cobbine as many bindings as you want

Hope changes are useful.
