### PR TITLE
Don't run ModelToView converter when validation fails

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -352,15 +352,15 @@
         },
 
         _copyViewToModel: function (elementBinding, el) {
-            var value, convertedValue;
+            var result, value, convertedValue;
 
             if (!el._isSetting) {
 
                 el._isSetting = true;
-                this._setModel(elementBinding, $(el));
+                result = this._setModel(elementBinding, $(el));
                 el._isSetting = false;
 
-                if(elementBinding.converter){
+                if(result && elementBinding.converter){
                     value = this._model.get(elementBinding.attributeBinding.attributeName);
                     convertedValue = this._getConvertedValue(Backbone.ModelBinder.Constants.ModelToView, elementBinding, value);
                     this._setEl($(el), elementBinding, convertedValue);
@@ -388,7 +388,7 @@
             elVal = this._getConvertedValue(Backbone.ModelBinder.Constants.ViewToModel, elementBinding, elVal);
             data[elementBinding.attributeBinding.attributeName] = elVal;
 	        var opts = _.extend({}, this._modelSetOptions, {changeSource: 'ModelBinder'});
-            this._model.set(data, opts);
+            return this._model.set(data, opts);
         },
 
         _getConvertedValue: function (direction, elementBinding, value) {


### PR DESCRIPTION
There's a problem with binding inputs to model attributes that fail validation.  If an element binding has a converter, a ModelToView conversion will run, _regardless_ of success or failure.  The converter runs against the last valid value in the model, which results in the user's input being reset.

The converter should only be executed when the validation succeeds because a) it doesn't make sense to attempt to run a converter against the invalid input data, b) it keeps the behavior consistent with input bindings that do not provide a converter, and c) it is the preferable user experience to keep the invalid input in the control so the user can correct it.
