### PR TITLE
Setting the class even when previous value is undefined

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -309,7 +309,9 @@
                     break;
                 case 'class':
                     var previousValue = this._model.previous(elementBinding.attributeBinding.attributeName);
-                    if(!_.isUndefined(previousValue)){
+		    var currentValue = this._model.get(elementBinding.attributeBinding.attributeName);
+		    // is current value is now defined then remove the class the may have been set for the undefined value
+                    if(!_.isUndefined(previousValue) || !_.isUndefined(currentValue)){
                         previousValue = this._getConvertedValue(Backbone.ModelBinder.Constants.ModelToView, elementBinding, previousValue);
                         el.removeClass(previousValue);
                     }


### PR DESCRIPTION
I came a across an issue where an attribute on the model was originally undefined at the time of binding, and converter function returned a, let's say, default class to be added to the dom element.  However, when the attribute was set (i.e. no longer undefined), because the previous value was undefined, the originally added class was not removed, since the previous value is check for being defined.  So, I think it is worth checking for a such condition by testing the current value of the attribute.  If the current value is defined then (regardless of whether or not previous value was defined) go ahead  and call  converter function and, consequently, remove the returned class from the dom element.  Please, consider this change, and don't hesitate to contact me for any further discussion.  Thank you.
