### PR TITLE
HTML inside contentEditable and null/undefined model attributes

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -376,7 +376,7 @@
                     return el.prop('checked') ? true : false;
                 default:
                     if(el.attr('contenteditable') !== undefined){
-                        return el.html();
+                        return el.text();
                     }
                     else {
                         return el.val();


### PR DESCRIPTION
Fix: In some cases, the value of a model attribute will be Null or Undefined. In these cases, the word 'null' or 'undefined' will show up on the page.
This fix just checks to make sure the value is present before inserting it in to the page.

Fix: In some cases, a bit of HTML will be inside an element that is contentEditable. For instance, an <br>. In this case, calling el.html() will return '<br>'. This will result in '<br>' being set as the value of the model attribute. Instead, just use el.text() which will not include any HTML from the element.
