### PR TITLE
Updated Prerequisites in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The ModelBinder eliminates these ineffeciencies by listening for model changes l
 <br>
 ## Prerequisites
 
-* Backbone.js v0.9.0 or higher
-* Underscore.js v1.3.1 or higher
-* jQuery v1.7.1 or higher
+* Backbone.js v1.0.0 or higher
+* Underscore.js v1.4.4 or higher
+* jQuery v1.8.3 or higher
 
 
 <br>


### PR DESCRIPTION
If I understand correctly, version 1.0.0 introduced changes in required libraries. I updated the 'Prerequisites' section in the README accordingly.

Additionally, do we need to mention Underscore? This is a required dependency of Backbone itself.
