### PR TITLE
When Collection.sort is called and autoSort is true, resort the list

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -1,4 +1,4 @@
-// Backbone.CollectionBinder v1.0.0
+// Backbone.CollectionBinder v1.0.1
 // (c) 2013 Bart Wood
 // Distributed Under MIT License
 
@@ -25,7 +25,7 @@
         this._options = options || {};
     };
 
-    Backbone.CollectionBinder.VERSION = '1.0.0';
+    Backbone.CollectionBinder.VERSION = '1.0.1';
 
     _.extend(Backbone.CollectionBinder.prototype, Backbone.Events, {
         bind: function(collection, parentEl){
@@ -42,7 +42,7 @@
             this._collection.on('add', this._onCollectionAdd, this);
             this._collection.on('remove', this._onCollectionRemove, this);
             this._collection.on('reset', this._onCollectionReset, this);
-
+            this._collection.on('sort', this._onCollectionSort, this);
         },
 
         unbind: function(){
@@ -50,6 +50,7 @@
                 this._collection.off('add', this._onCollectionAdd);
                 this._collection.off('remove', this._onCollectionRemove);
                 this._collection.off('reset', this._onCollectionReset);
+                this._collection.off('sort', this._onCollectionSort);
             }
 
             this._removeAllElManagers();
@@ -104,6 +105,12 @@
             }, this);
 
             this.trigger('elsReset', this._collection);
+        },
+
+        _onCollectionSort: function() {
+            if(this._options['autoSort']){
+                this.sortRootEls();
+            }
         },
 
         _removeAllElManagers: function(){


### PR DESCRIPTION
This is just a quick change to allow Collections to be resorted when using CollectionBinder. Whenever Collection.sort is invoked (e.g. when resorting a grid by column heading) then apply the CollectionBinder sorting to DOM elements as well.

Since I couldn't find any test specs related to autosort, I didn't add any additionals for this (would have taken too long, sorry). If I've missed something obvious, let me know and I'll add specs.
