### PR TITLE
made binding of optional model attributes possible

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -162,7 +162,8 @@
                     }
 
                     if (foundEls.length === 0) {
-                        this._throwException('Bad binding found. No elements returned for binding selector ' + elementBinding.selector);
+                        this._throwException('No elements returned for binding selector ' + elementBinding.selector);
+                        elementBinding.boundEls = [];
                     }
                     else {
                         elementBinding.boundEls = [];


### PR DESCRIPTION
Removed "Bad binding found."
Set elementBinding.boundEls = [];

This allows you to use ModelBinder with models that have optional attributes that may or may not show up in the DOM at any given time.
