### PR TITLE
Allow the ModelBinder to work with current Node jquery

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -129,7 +129,7 @@
             var elCount, elsWithAttribute, matchedEl, name, attributeBinding;
 
             this._attributeBindings = {};
-            elsWithAttribute = $('[' + this._options['boundAttribute'] + ']', this._rootEl);
+            elsWithAttribute = $('[' + this._options['boundAttribute'] + '!=""]', this._rootEl);
 
             for(elCount = 0; elCount < elsWithAttribute.length; elCount++){
                 matchedEl = elsWithAttribute[elCount];
@@ -523,7 +523,7 @@
         var foundEls, elCount, foundEl, attributeName;
         var bindings = {};
 
-        foundEls = $('[' + attributeType + ']', rootEl);
+        foundEls = $('[' + attributeType + '!=""]', rootEl);
 
         for(elCount = 0; elCount < foundEls.length; elCount++){
             foundEl = foundEls[elCount];


### PR DESCRIPTION
The default method to find elements on the code was:
$('[name]', rootEl);
But this can end up selecting elements where the attribute exists but is blank, and this makes no sense on data binding.
With this fix this will not happen anymore.
The main drive to fix this is to run tests on Node, using JSDom and NPM's jquery. There is a bug on Node's jquery where the attribute selector does not work as expected and always selects all elements, regardless if they have the attribute or not. This fixes that as well.
Because of this problem, on Node nothing would work unless the elements  being bound where direct children of the RootEl.
This fix will allow the ModelBinder to work on the browser and on Node.
