### PR TITLE
Leveraged underscore templating to allow dynamic html to be generated based on each model in the collection

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -165,8 +165,8 @@
                 _model: model,
 
                 createEl: function(){
-
-                    this._el =  $(this._elHtml);
+                    this._template = _.template(this._elHtml, {model: model});
+                    this._el =  $(this._template);
                     $(this._parentEl).append(this._el);
 
                     if(this._bindings){


### PR DESCRIPTION
Passed the model through so that users can submit templates to the collection binder instead of just simple html strings

Developed in response to issue #148, but I created it generically so that it passes the whole model through.  This does not interfere with current functionality, anyone using basic html strings will simply pass through _.template and come back exactly the same without modifications.
