### PR TITLE
Empty hash passed as attributeBindings should not make any effects

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -43,7 +43,7 @@
             if (!this._model) this._throwException('model must be specified');
             if (!this._rootEl) this._throwException('rootEl must be specified');
 
-            if(attributeBindings){
+            if(!_.isEmpty(attributeBindings)){
                 // Create a deep clone of the attribute bindings
                 this._attributeBindings = $.extend(true, {}, attributeBindings);
 


### PR DESCRIPTION
Currently when specifying options for ModelBinder.bind method we need to pass null for attributeBindings argument.

``` javascript
modelBinder = new Backbone.ModelBinder()
modelBinder.bind(model, el, null, {modelSetOptions: {silent: true}})
```

It's very common to pass empty hash if you want to skip values for first options argument. But then ModelBinder will not initialize default bindings since {} is a true value.

``` javascript
modelBinder = new Backbone.ModelBinder()
modelBinder.bind(model, el, {}, {modelSetOptions: {silent: true}})
```

This pull request fixes second case by checking whether attributeBindings is an empty object or null.
