### PR TITLE
Add typeof to check if console is available

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -478,7 +478,7 @@
 
         _throwException: function(message){
             if(this._options.suppressThrows){
-                if(console && console.error){
+                if(typeof(console) !== 'undefined' && console.error){
                     console.error(message);
                 }
             }


### PR DESCRIPTION
Without a `typeof` check, IE8 raise an JavaScript error with message _"console is undefined"_.
