### PR TITLE
Trivial, missing semicolon causes Jenkins warning

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -60,7 +60,7 @@
 
         bindCustomTriggers: function (model, rootEl, triggers, attributeBindings, modelSetOptions) {
             this._triggers = triggers;
-            this.bind(model, rootEl, attributeBindings, modelSetOptions)
+            this.bind(model, rootEl, attributeBindings, modelSetOptions);
         },
 
         unbind:function () {


### PR DESCRIPTION
Hi, I know this is trivial change and missing semicolon didn't actually break anything, but I wanted to pull this just for the sake of proper JavaScript syntax.

Discovered when my jslint task on Jenkins detected an error in ModelBinder code.
