### PR TITLE
Check for console.log to support Internet Explorer

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -253,7 +253,7 @@
                     }
                     else {
                         this._view.$el.remove();
-                        console.log('warning, you should implement a close() function for your view, you might end up with zombies');
+                        console && console.log && console.log('warning, you should implement a close() function for your view, you might end up with zombies');
                     }
 
                     this.trigger('elRemoved', this._model, this._view);


### PR DESCRIPTION
Internet Explorer doesn't provide `console` or `console.log` unless you are running in development mode. Hopefully your users don't get to this point, but if they do, crashing the app for this would suck.
