### PR TITLE
Add note about empty selector to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,18 @@ To define multiple selectors, just define them as an array.
 
 The jQuery bindings leverage the jQuery delegate mechanism - which means they should be fairly efficient.
 
+##Binding to the Root Element##
+
+Sometimes, in rare cases, your views are so simple that you just want to bind
+to the root element itself. For example, if your view is an `<li>` tag, it
+makes sense to have the inner HTML simply be the appropriate model value.
+
+In those cases, simply use an empty string as your selector:
+
+````
+ firstName: { selector: '' }
+````
+
 <br>
 ***
 


### PR DESCRIPTION
This will add some documentation to the README about using an empty selector string to bind to the root element of a view (`this.$el`).

N.B. The README does mention that this functionality was added in v0.1.1, but there isn't anything in the documentation itself about it. So this is just a first pass at adding that functionality. If anyone wants to change the language, feel free-- I am not a copywriter :-)

This was inspired by issue #179.