### PR TITLE
Bindings and failed validation

### DIFF
--- a/Backbone.ModelBinder.js
+++ b/Backbone.ModelBinder.js
@@ -433,18 +433,23 @@
         },
 
         _copyViewToModel: function (elementBinding, el) {
-            var result, value, convertedValue;
+            var result, value, convertedValue, attributeName;
 
             if (!el._isSetting) {
+                attributeName = elementBinding.attributeBinding.attributeName;
 
                 el._isSetting = true;
                 result = this._setModel(elementBinding, $(el));
                 el._isSetting = false;
 
                 if(result && elementBinding.converter){
-                    value = this._model.get(elementBinding.attributeBinding.attributeName);
+                    value = this._model.get(attributeName);
                     convertedValue = this._getConvertedValue(Backbone.ModelBinder.Constants.ModelToView, elementBinding, value);
                     this._setEl($(el), elementBinding, convertedValue);
+                } else if (result === false) {
+                    // Model set failed for some reason, so revert the element
+                    // by copying the model back over.
+                    this.copyModelAttributesToView([attributeName]);
                 }
             }
         },

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -71,6 +71,7 @@
   <script type="text/javascript" src="javascripts/coreBinder.spec.js"></script>
   <script type="text/javascript" src="javascripts/defaultBindings.spec.js"></script>
   <script type="text/javascript" src="javascripts/oneElementToMultipleAttributes.spec.js"></script>
+  <script type="text/javascript" src="javascripts/bindingAndValidation.spec.js"></script>
 
 </head>
   <body>

--- a/spec/javascripts/bindingAndValidation.spec.js
+++ b/spec/javascripts/bindingAndValidation.spec.js
@@ -59,7 +59,7 @@ describe("binding and validations", function () {
         });
 
         it("should not have succeeded", function () {
-            expect(this.result).toBeFalsy();
+            expect(this.result).toBe(false);
         });
 
         it("should not have affected the model", function () {

--- a/spec/javascripts/bindingAndValidation.spec.js
+++ b/spec/javascripts/bindingAndValidation.spec.js
@@ -1,0 +1,101 @@
+describe("binding and validations", function () {
+    var ValidatingModel = Backbone.Model.extend({
+        validate: function (attrs) {
+            if (!attrs.name) {
+                return "name not found";
+            }
+        }
+    });
+
+    var View = Backbone.View.extend({
+        initialize: function () {
+            this.modelBinder = new Backbone.ModelBinder();
+        },
+        render: function () {
+            this.$el.append('<input type="text" id="name">');
+            this.modelBinder.bind(
+                this.model,
+                this.$el,
+                this.bindings,
+                { modelSetOptions: { validate: true } }
+            );
+        },
+        bindings: {
+            name: "#name"
+        }
+    });
+
+    beforeEach(function () {
+        this.model = new ValidatingModel({ name: "initial" });
+        this.view = new View({ model: this.model });
+        this.view.render();
+    });
+
+    describe("setting model to valid value", function () {
+        beforeEach(function () {
+            this.result = this.model.set({
+                name: "valid name"
+            }, { validate: true });
+        });
+
+        it("should have succeeded", function () {
+            expect(this.result).toBeTruthy();
+        });
+
+        it("should have affected the model", function () {
+            expect(this.model.get("name")).toBe("valid name");
+        });
+
+        it("should have affected the view", function () {
+            expect(this.view.$("#name").val()).toBe("valid name");
+        });
+    });
+
+    describe("setting model to invalid value", function () {
+        beforeEach(function () {
+            this.result = this.model.set({
+                name: ""
+            }, { validate: true });
+        });
+
+        it("should not have succeeded", function () {
+            expect(this.result).toBeFalsy();
+        });
+
+        it("should not have affected the model", function () {
+            expect(this.model.get("name")).not.toBe("");
+        });
+
+        it("should not have affected the view", function () {
+            expect(this.view.$("#name").val()).not.toBe("");
+        });
+    });
+
+    describe("setting view to valid value", function () {
+        beforeEach(function () {
+            this.view.$("#name").val("valid name").trigger("change");
+        });
+
+        it("should have affected the model", function () {
+            expect(this.model.get("name")).toBe("valid name");
+        });
+
+        it("should have persisted in the view", function () {
+            expect(this.view.$("#name").val()).toBe("valid name");
+        });
+    });
+
+    describe("setting view to invalid value", function () {
+        beforeEach(function () {
+            this.view.$("#name").val("").trigger("change");
+        });
+
+        it("should not have affected the model", function () {
+            expect(this.model.get("name")).not.toBe("");
+        });
+
+        it("should not have persisted in the view", function () {
+            expect(this.view.$("#name").val()).not.toBe("");
+        });
+    });
+});


### PR DESCRIPTION
Fixes #178. Note that this is potentially a breaking change.

The basic idea is that if changing the view causes a model set, and that model set fails (ostensibly due to validation errors), the previous model attribute should be copied back over into the view so that the model and view are back in sync.

If this is deemed to be too much of a breaking change, I can augment the pull request to support a new ModelBinder option to enable this behavior (e.g., `revertViewOnValidationError` or something similar). Just let me know.

Patch impact:
- If this is merged as is, a release version bump (2.0.0 as of this writing) may be needed.
- If this is controlled by a new ModelBinder option, only a major version bump (1.1.0 as of this writing) would be needed.

If this change is rejected outright (even with a ModelBinder option), I'll probably create a new pull request with just the test file (minus the last assertion), so that we have _some_ coverage around ModelBinder plus validation. Presumably that would only need a minor version update.
