### PR TITLE
CollectionBinder: Don't rely on 'chained' behavior of View.render

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -260,7 +260,8 @@
 
                 createEl: function(){
                     this._view = this._viewCreator(model);
-                    $(this._parentEl).append(this._view.render(this._model).el);
+                    this._view.render(this._model);
+                    $(this._parentEl).append(this._view.el);
 
                     this.trigger('elCreated', this._model, this._view);
                 },


### PR DESCRIPTION
Usually a developer is not required to enable chaining for view.render method by returning 'this'.
This commit rewrites the elManager.createEl code to not rely on such chaining.