### PR TITLE
CollectionBinder: don't sort elements on 'add' event

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -100,10 +100,6 @@
         _onCollectionAdd: function(model){
             this._elManagers[model.cid] = this._elManagerFactory.makeElManager(model);
             this._elManagers[model.cid].createEl();
-
-            if(this._options['autoSort']){
-                this.sortRootEls();
-            }
         },
 
         _onCollectionRemove: function(model){

--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -97,9 +97,15 @@
            return this._elManagers[_.isObject(model)? model.cid : model];
         },
 
-        _onCollectionAdd: function(model){
-            this._elManagers[model.cid] = this._elManagerFactory.makeElManager(model);
-            this._elManagers[model.cid].createEl();
+        _onCollectionAdd: function(model, collection, options){
+            var manager = this._elManagers[model.cid] = this._elManagerFactory.makeElManager(model);
+            manager.createEl();
+
+            var position = options && options.at;
+
+            if (this._options['autoSort'] && position != null && position < this._collection.length - 1) {
+                this._moveElToPosition(manager.getEl(), position);
+            }
         },
 
         _onCollectionRemove: function(model){
@@ -137,6 +143,20 @@
                 this._elManagers[model.cid].removeEl();
                 delete this._elManagers[model.cid];
             }
+        },
+
+        _moveElToPosition: function (modelEl, position) {
+            var nextModel = this._collection.at(position + 1);
+            if (!nextModel) return;
+
+            var nextManager = this.getManagerForModel(nextModel);
+            if (!nextManager) return;
+
+            var nextEl = nextManager.getEl();
+            if (!nextEl) return;
+
+            modelEl.detach();
+            modelEl.insertBefore(nextEl);
         },
 
         sortRootEls: function(){

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -45,6 +45,7 @@
     <script type="text/javascript" src="../lib/jquery.js"></script>
     <script type="text/javascript" src="../lib/backbone.js"></script>
     <script type="text/javascript" src="../Backbone.ModelBinder.js"></script>
+	<script type="text/javascript" src="../Backbone.CollectionBinder.js"></script>
 
 
     <!-- include spec files here... -->
@@ -71,6 +72,8 @@
   <script type="text/javascript" src="javascripts/coreBinder.spec.js"></script>
   <script type="text/javascript" src="javascripts/defaultBindings.spec.js"></script>
   <script type="text/javascript" src="javascripts/oneElementToMultipleAttributes.spec.js"></script>
+
+  <script type="text/javascript" src="javascripts/CollectionBinder/sorting.spec.js"></script>
 
 </head>
   <body>

--- a/spec/javascripts/CollectionBinder/sorting.spec.js
+++ b/spec/javascripts/CollectionBinder/sorting.spec.js
@@ -1,0 +1,236 @@
+describe("CollectionBinder: sorting", function(){
+
+    var NestedView = Backbone.View.extend({
+        className: 'nested-view',
+        render: function () {
+            this.$el.addClass('nested-' + this.model.id);
+            return this;
+        },
+
+        close: function () {
+            this.remove();
+        }
+    });
+
+    var ParentView = Backbone.View.extend({
+        className: 'parentView',
+
+        collectionBinderOptions: {
+            autoSort: false
+        },
+
+        initialize: function () {
+            var elManagerFactory = new Backbone.CollectionBinder.ViewManagerFactory(function (model) {
+                return new NestedView({
+                    model: model
+                });
+            });
+
+            this.collectionBinder = new Backbone.CollectionBinder(elManagerFactory, this.collectionBinderOptions);
+        },
+
+        render: function () {
+            this.collectionBinder.bind(this.collection, this.$el);
+            return this;
+        },
+
+        remove: function () {
+            this.collectionBinder.unbind();
+            Backbone.View.prototype.remove.apply(this, arguments);
+        },
+
+        getNestedElementIndex: function (id) {
+            return this.$('.nested-' + id).index();
+        }
+    });
+
+    var ParentViewAutoSort = ParentView.extend({
+        collectionBinderOptions: {
+            autoSort: true
+        }
+    });
+
+
+    var createViewForTest = function (View, collection) {
+        var view = new View ({collection: collection});
+        view.render();
+
+        this.view = view;
+
+        return view;
+    };
+
+
+    beforeEach(function(){
+        this.collection = new Backbone.Collection([]);
+        this.collection.comparator = 'id';
+        this.unorderedCollection = new Backbone.Collection([]);
+    });
+
+    afterEach(function () {
+        if (this.view) this.view.remove();
+    });
+
+
+    // The default behavior with autoSort:false is to always append views for the newly added models to the end
+    // Probably not very useful except in very simple cases
+    describe('With autoSort: false', function () {
+        var createView = function (collection) {
+            return createViewForTest(ParentView, collection);
+        };
+
+        it('Should ignore models order on collection.add', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.add({id: 1});
+            this.collection.add({id: 0});
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the order of .add calls, regardless on collection sort order
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            expect(view.getNestedElementIndex(0)).toBe(1);
+        });
+
+        it('Should ignore models order on collection.set', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.set([{id: 1}, {id: 0}]);
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the order of .add calls, regardless on collection sort order
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            expect(view.getNestedElementIndex(0)).toBe(1);
+        });
+
+        it('Should ignore models order on collection.add with {at: some-index}', function () {
+            var view = createView(this.unorderedCollection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.unorderedCollection.add({id: 1});
+            this.unorderedCollection.add({id: 0}, {at: 0});
+
+            // models should have been re-ordered according to at:0 option
+            expect(this.unorderedCollection.at(0).id).toBe(0);
+            expect(this.unorderedCollection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the order of .add calls, regardless on the 'at' option
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            expect(view.getNestedElementIndex(0)).toBe(1);
+        });
+
+        it('Should not rearrange elements on collection.sort()', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.reset([{id: 1}, {id: 2}]);
+
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            expect(view.getNestedElementIndex(2)).toBe(1);
+
+            this.collection.get(2).set({id: 0});
+            this.collection.sort();
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the order of .add calls, regardless on collection sort order
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            // use the old value of 'id' because the view doesn't automatically update on model changes
+            expect(view.getNestedElementIndex(2)).toBe(1);
+        });
+    });
+
+
+
+    describe('With autoSort: true', function () {
+        var createView = function (collection) {
+            return createViewForTest(ParentViewAutoSort, collection);
+        };
+
+        it('Should respect models order on collection.add', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.add({id: 1});
+            this.collection.add({id: 0});
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the new order of models in the collection
+            expect(view.getNestedElementIndex(0)).toBe(0);
+            expect(view.getNestedElementIndex(1)).toBe(1);
+        });
+
+        it('Should respect models order on collection.set', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.set([{id: 1}, {id: 0}]);
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the new order of models in the collection
+            expect(view.getNestedElementIndex(0)).toBe(0);
+            expect(view.getNestedElementIndex(1)).toBe(1);
+        });
+
+        it('Should respect models order on collection.add with {at: some-index}', function () {
+            var view = createView(this.unorderedCollection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.unorderedCollection.add({id: 1});
+            this.unorderedCollection.add({id: 0}, {at: 0});
+
+            // models should have been re-ordered according to at:0 option
+            expect(this.unorderedCollection.at(0).id).toBe(0);
+            expect(this.unorderedCollection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the new order of models in the collection
+            expect(view.getNestedElementIndex(0)).toBe(0);
+            expect(view.getNestedElementIndex(1)).toBe(1);
+        });
+
+        it('Should rearrange elements on collection.sort()', function () {
+            var view = createView(this.collection);
+
+            var collectionBinder = view.collectionBinder;
+
+            this.collection.reset([{id: 1}, {id: 2}]);
+
+            expect(view.getNestedElementIndex(1)).toBe(0);
+            expect(view.getNestedElementIndex(2)).toBe(1);
+
+            this.collection.get(2).set({id: 0});
+            this.collection.sort();
+
+            // models should have been re-ordered by the collection
+            expect(this.collection.at(0).id).toBe(0);
+            expect(this.collection.at(1).id).toBe(1);
+
+            // the order of elements should reflect the new order of models in the collection
+            // use the old value of 'id' because the view doesn't automatically update on model changes
+            expect(view.getNestedElementIndex(2)).toBe(0);
+            expect(view.getNestedElementIndex(1)).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
Backbone triggers 'sort' each time an model was added to the collection if it changed the sort order.
So there is no point in sorting dom elements on 'add' event - doing that on 'sort' would be enough.

What's more, it leads to broken collection rendering on collection.set, as `sortRootEls` is called after each individual `add` event is triggered - at this point the collection has the full set of models, but only some of them have been rendered. One of the added unit tests fails with the original code due to that.