### PR TITLE
Fix: missing element in autosorted collection

### DIFF
--- a/Backbone.CollectionBinder.js
+++ b/Backbone.CollectionBinder.js
@@ -150,7 +150,7 @@
                     var modelEl = modelElManager.getEl();
                     var currentRootEls = $(this._elManagerFactory._getParentEl()).children();
 
-                    if(currentRootEls[modelIndex] !== modelEl[0]){
+                    if(modelIndex < currentRootEls.length && currentRootEls[modelIndex] !== modelEl[0]){
                         modelEl.detach();
                         modelEl.insertBefore(currentRootEls[modelIndex]);
                     }


### PR DESCRIPTION
In some cases not all elements are rendered.

The reason for this is following:
1) If 'autoSort' is switched on the collection is sorted immediately.
2) The elements are rendered in initial order.
3) After every element is rendered, sorting is called that compares order of HTML elements with order of items in sorted collection.
4) If the current HTML element must be inserted before the element that is not rendered yet, we loose the current element.

The solution is in checking count of rendered elements.